### PR TITLE
feat: added langfuse controls

### DIFF
--- a/langfuse/unify/__init__.py
+++ b/langfuse/unify/__init__.py
@@ -1,1 +1,3 @@
-from .unify_integration import unify, Unify, AsyncUnify, ChatBot
+from unify_integration import unify, Unify, AsyncUnify, ChatBot
+
+__all__ = ["unify", "Unify", "AsyncUnify", "ChatBot"]

--- a/langfuse/unify/__init__.py
+++ b/langfuse/unify/__init__.py
@@ -1,3 +1,3 @@
-from unify_integration import unify, Unify, AsyncUnify, ChatBot
+from .unify_integration import unify, Unify, AsyncUnify, ChatBot, auth_check
 
-__all__ = ["unify", "Unify", "AsyncUnify", "ChatBot"]
+__all__ = ["unify", "Unify", "AsyncUnify", "ChatBot", "auth_check"]

--- a/langfuse/unify/__init__.py
+++ b/langfuse/unify/__init__.py
@@ -1,3 +1,3 @@
-from .unify_integration import unify, Unify, AsyncUnify, ChatBot, auth_check
+from .unify_integration import unify, Unify, AsyncUnify, ChatBot
 
-__all__ = ["unify", "Unify", "AsyncUnify", "ChatBot", "auth_check"]
+__all__ = ["unify", "Unify", "AsyncUnify", "ChatBot"]

--- a/langfuse/unify/test_file.py
+++ b/langfuse/unify/test_file.py
@@ -1,0 +1,68 @@
+# from langfuse.unify import unify
+# from langfuse.unify import openai
+from __init__ import unify
+import os
+from dotenv import load_dotenv
+
+load_dotenv()
+
+print(f"LangFuse Enabled: {unify.langfuse_enabled}")
+path = os.environ["PATH"]
+unify.langfuse_secret_key = os.getenv("LANGFUSE_SECRET_KEY")
+unify.langfuse_public_key = os.getenv("LANGFUSE_PUBLIC_KEY")
+unify.langfuse_host = os.getenv("LANGFUSE_HOST")
+unify_api_key = os.getenv("UNIFY_API_KEY")
+print(f"LangFuse host: {unify.langfuse_host}")
+
+client = unify.Unify(
+    endpoint="mistral-7b-instruct-v0.2@fireworks-ai", api_key=unify_api_key
+)
+
+
+# @observe()  # decorator to automatically create trace and nest generations
+def main(country: str, user_id: str, **kwargs) -> str:
+    # nested generation 1: use openai to get capital of country
+    global client
+    capital = client.generate(
+        messages=[
+            {
+                "role": "system",
+                "content": "You are a Geography teacher helping students learn the capitals of countries. Output only the capital when being asked.",
+            },
+            {"role": "user", "content": country},
+        ]
+    )
+    print(capital)
+    capital_input = capital
+    # nested generation 2: use openai to write poem on capital
+    poem = client.generate(
+        messages=[
+            {
+                "role": "system",
+                "content": "You are a poet. Create a poem about a city.",
+            },
+            {"role": "user", "content": capital_input},
+        ]
+    )
+
+    # rename trace and set attributes (e.g., medatata) as needed
+    # langfuse_context.update_current_trace(
+    #     name="City poem generator",
+    #     session_id="1234",
+    #     user_id=user_id,
+    #     tags=["tag1", "tag2"],
+    #     public=True,
+    #     metadata={
+    #         "env": "development",
+    #     },
+    #     release="v0.0.21",
+    # )
+
+    return poem
+
+
+# create random trace_id, could also use existing id from your application, e.g. conversation id
+trace_id = "0"
+
+# run main function, set your own id, and let Langfuse decorator do the rest
+print(main("Bulgaria", "admin", langfuse_observation_id=trace_id))

--- a/langfuse/unify/test_file.py
+++ b/langfuse/unify/test_file.py
@@ -1,11 +1,11 @@
 # from langfuse.unify import unify
 # from langfuse.unify import openai
-from __init__ import unify
+from unify_integration import unify
 import os
 from dotenv import load_dotenv
 
 load_dotenv()
-
+print(f"LangFuse auth_check: {unify.auth_check()}")
 print(f"LangFuse Enabled: {unify.langfuse_enabled}")
 path = os.environ["PATH"]
 unify.langfuse_secret_key = os.getenv("LANGFUSE_SECRET_KEY")

--- a/langfuse/unify/unify_integration.py
+++ b/langfuse/unify/unify_integration.py
@@ -20,7 +20,7 @@ See docs for more details: https://langfuse.com/docs/integrations/openai
 from typing import Optional, List, Dict, Generator, AsyncGenerator
 from unify.exceptions import status_error_map
 from langfuse.utils.langfuse_singleton import LangfuseSingleton
-from langfuse.openai import openai, OpenAILangfuse
+from langfuse.openai import openai, OpenAILangfuse, auth_check, _filter_image_data
 
 try:
     import unify
@@ -51,6 +51,8 @@ class UnifyLangfuse(OpenAILangfuse):
         setattr(unify, "langfuse_debug", openai.langfuse_debug)
         setattr(unify, "langfuse_enabled", openai.langfuse_enabled)
         setattr(unify, "flush_langfuse", openai.flush_langfuse)
+        setattr(unify, "auth_check", auth_check)
+        setattr(unify, "_filter_image_data", _filter_image_data)
 
 
 modifier = UnifyLangfuse()


### PR DESCRIPTION
<!--
This template will help you to have a meaningful PR, please follow it and do not leave it blank.
-->

# PR Description

As in the title. Unify can now have values assigned to dedicated langfuse parameters and they will get passed on to langfuse's trace. Example:

```py
unify.langfuse_public_key = os.getenv("LANGFUSE_PUBLIC_KEY")
```

<!--
If there is no related issue, please add a short description about your PR.
-->

## Related Issue

<!--
Please use this format to link other issues with their numbers: Close #123
https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
-->

Closes #32

## Checklist

- [x] Did you add a feature?
- [ ] Did you add the tests?
- [ ] Did you run your tests and are your tests passing?
- [ ] Did you follow the steps we provided?

<!--
Please mark your PR as a draft if you realise after the fact that your tests are not passing or
that your pre-commit check has some failures.

-->

### Socials

<!--
If you have Twitter, please provide it here otherwise just ignore this.
-->
