### PR TITLE
feat: wrap OpenaAILangfuse to swap langfuse parameters of openai with corresponding parameters of unify

### DIFF
--- a/langfuse/unify/__init__.py
+++ b/langfuse/unify/__init__.py
@@ -1,3 +1,17 @@
-from .unify_integration import unify, Unify, AsyncUnify, ChatBot
+from .unify_integration import (
+    unify,
+    Unify,
+    AsyncUnify,
+    ChatBot,
+    auth_check,
+    _filter_image_data,
+)
 
-__all__ = ["unify", "Unify", "AsyncUnify", "ChatBot"]
+__all__ = [
+    "unify",
+    "Unify",
+    "AsyncUnify",
+    "ChatBot",
+    "auth_check",
+    "_filter_image_data",
+]

--- a/langfuse/unify/test_file.py
+++ b/langfuse/unify/test_file.py
@@ -1,19 +1,20 @@
 # from langfuse.unify import unify
 # from langfuse.unify import openai
-from unify_integration import unify, auth_check
+from unify_integration import unify
 import os
 from dotenv import load_dotenv
 from langfuse.decorators import observe
 
 load_dotenv()
+os.environ["LANGFUSE_PUBLIC_KEY"] = ""
 print(f"LangFuse Enabled: {unify.langfuse_enabled}")
 path = os.environ["PATH"]
 unify.langfuse_secret_key = os.getenv("LANGFUSE_SECRET_KEY")
-unify.langfuse_public_key = os.getenv("LANGFUSE_PUBLIC_KEY")
+unify.langfuse_public_key = os.getenv("LANGFUSE_PK")
 unify.langfuse_host = os.getenv("LANGFUSE_HOST")
 unify_api_key = os.getenv("UNIFY_API_KEY")
 print(f"LangFuse host: {unify.langfuse_host}")
-print(f"UnifyLangfuse auth_check: {auth_check()}")
+# print(f"UnifyLangfuse auth_check: {auth_check()}")
 client = unify.Unify(
     endpoint="mistral-7b-instruct-v0.2@fireworks-ai", api_key=unify_api_key
 )

--- a/langfuse/unify/test_file.py
+++ b/langfuse/unify/test_file.py
@@ -3,6 +3,7 @@
 from unify_integration import unify, auth_check
 import os
 from dotenv import load_dotenv
+from langfuse.decorators import observe
 
 load_dotenv()
 print(f"LangFuse Enabled: {unify.langfuse_enabled}")
@@ -18,7 +19,7 @@ client = unify.Unify(
 )
 
 
-# @observe()  # decorator to automatically create trace and nest generations
+@observe()  # decorator to automatically create trace and nest generations
 def main(country: str, user_id: str, **kwargs) -> str:
     # nested generation 1: use openai to get capital of country
     global client
@@ -64,4 +65,4 @@ def main(country: str, user_id: str, **kwargs) -> str:
 trace_id = "0"
 
 # run main function, set your own id, and let Langfuse decorator do the rest
-print(main("Bulgaria", "admin", langfuse_observation_id=trace_id))
+print(main("Bulgaria", "admin"))

--- a/langfuse/unify/test_file.py
+++ b/langfuse/unify/test_file.py
@@ -5,7 +5,6 @@ import os
 from dotenv import load_dotenv
 
 load_dotenv()
-print(f"LangFuse auth_check: {unify.auth_check()}")
 print(f"LangFuse Enabled: {unify.langfuse_enabled}")
 path = os.environ["PATH"]
 unify.langfuse_secret_key = os.getenv("LANGFUSE_SECRET_KEY")

--- a/langfuse/unify/test_file.py
+++ b/langfuse/unify/test_file.py
@@ -5,12 +5,13 @@ import os
 from dotenv import load_dotenv
 from langfuse.decorators import observe
 
+
 load_dotenv()
 os.environ["LANGFUSE_PUBLIC_KEY"] = ""
 print(f"LangFuse Enabled: {unify.langfuse_enabled}")
 path = os.environ["PATH"]
 unify.langfuse_secret_key = os.getenv("LANGFUSE_SECRET_KEY")
-unify.langfuse_public_key = os.getenv("LANGFUSE_PK")
+unify.langfuse_public_key = os.getenv("LANGFUSE_PUBLIC_KEY")
 unify.langfuse_host = os.getenv("LANGFUSE_HOST")
 unify_api_key = os.getenv("UNIFY_API_KEY")
 print(f"LangFuse host: {unify.langfuse_host}")

--- a/langfuse/unify/test_file.py
+++ b/langfuse/unify/test_file.py
@@ -7,7 +7,6 @@ from langfuse.decorators import observe
 
 
 load_dotenv()
-os.environ["LANGFUSE_PUBLIC_KEY"] = ""
 print(f"LangFuse Enabled: {unify.langfuse_enabled}")
 path = os.environ["PATH"]
 unify.langfuse_secret_key = os.getenv("LANGFUSE_SECRET_KEY")

--- a/langfuse/unify/test_file.py
+++ b/langfuse/unify/test_file.py
@@ -1,6 +1,6 @@
 # from langfuse.unify import unify
 # from langfuse.unify import openai
-from unify_integration import unify, auth_check
+from unify_integration import unify
 import os
 from dotenv import load_dotenv
 from langfuse.decorators import observe
@@ -14,7 +14,7 @@ unify.langfuse_public_key = os.getenv("LANGFUSE_PUBLIC_KEY")
 unify.langfuse_host = os.getenv("LANGFUSE_HOST")
 unify_api_key = os.getenv("UNIFY_API_KEY")
 print(f"LangFuse host: {unify.langfuse_host}")
-print(f"UnifyLangfuse auth_check: {auth_check()}")
+# print(f"UnifyLangfuse auth_check: {auth_check()}")
 client = unify.Unify(
     endpoint="mistral-7b-instruct-v0.2@fireworks-ai", api_key=unify_api_key
 )

--- a/langfuse/unify/test_file.py
+++ b/langfuse/unify/test_file.py
@@ -1,6 +1,6 @@
 # from langfuse.unify import unify
 # from langfuse.unify import openai
-from unify_integration import unify
+from unify_integration import unify, auth_check
 import os
 from dotenv import load_dotenv
 
@@ -12,7 +12,7 @@ unify.langfuse_public_key = os.getenv("LANGFUSE_PUBLIC_KEY")
 unify.langfuse_host = os.getenv("LANGFUSE_HOST")
 unify_api_key = os.getenv("UNIFY_API_KEY")
 print(f"LangFuse host: {unify.langfuse_host}")
-
+print(f"UnifyLangfuse auth_check: {auth_check()}")
 client = unify.Unify(
     endpoint="mistral-7b-instruct-v0.2@fireworks-ai", api_key=unify_api_key
 )

--- a/langfuse/unify/test_file.py
+++ b/langfuse/unify/test_file.py
@@ -1,6 +1,6 @@
 # from langfuse.unify import unify
 # from langfuse.unify import openai
-from unify_integration import unify
+from unify_integration import unify, auth_check
 import os
 from dotenv import load_dotenv
 from langfuse.decorators import observe
@@ -15,7 +15,7 @@ unify.langfuse_public_key = os.getenv("LANGFUSE_PUBLIC_KEY")
 unify.langfuse_host = os.getenv("LANGFUSE_HOST")
 unify_api_key = os.getenv("UNIFY_API_KEY")
 print(f"LangFuse host: {unify.langfuse_host}")
-# print(f"UnifyLangfuse auth_check: {auth_check()}")
+print(f"UnifyLangfuse auth_check: {auth_check()}")
 client = unify.Unify(
     endpoint="mistral-7b-instruct-v0.2@fireworks-ai", api_key=unify_api_key
 )

--- a/langfuse/unify/unify_integration.py
+++ b/langfuse/unify/unify_integration.py
@@ -121,7 +121,7 @@ class UnifyLangfuse(OpenAILangfuse):
 
 OpenAILangfuse.initialize = UnifyLangfuse.initialize
 modifier = UnifyLangfuse()
-modifier.unify_tracing()
+modifier.reregister_tracing()
 
 
 class Unify(Unify):

--- a/langfuse/unify/unify_integration.py
+++ b/langfuse/unify/unify_integration.py
@@ -18,13 +18,12 @@ See docs for more details: https://langfuse.com/docs/integrations/openai
 """
 
 from langfuse.utils.langfuse_singleton import LangfuseSingleton
+from langfuse.client import Langfuse
 from typing import Optional, List, Dict, Generator, AsyncGenerator
 from unify.exceptions import status_error_map
 from langfuse.openai import (
     openai,
     OpenAILangfuse,
-    auth_check,
-    _filter_image_data,
 )
 
 
@@ -37,11 +36,10 @@ except ImportError:
 
 from unify import Unify, AsyncUnify, ChatBot
 
-auth_check = auth_check
-_filter_image_data = _filter_image_data
-
 
 class UnifyLangfuse(OpenAILangfuse):
+    _langfuse: Optional[Langfuse] = None
+
     def initialize(self):
         self._langfuse = LangfuseSingleton().get(
             public_key=unify.langfuse_public_key,

--- a/langfuse/unify/unify_integration.py
+++ b/langfuse/unify/unify_integration.py
@@ -20,7 +20,8 @@ See docs for more details: https://langfuse.com/docs/integrations/openai
 from typing import Optional, List, Dict, Generator, AsyncGenerator
 from unify.exceptions import status_error_map
 from langfuse.utils.langfuse_singleton import LangfuseSingleton
-from langfuse.openai import openai, OpenAILangfuse
+from langfuse.openai import openai, OpenAILangfuse, auth_check, _filter_image_data
+
 
 try:
     import unify
@@ -30,6 +31,9 @@ except ImportError:
     )
 
 from unify import Unify, AsyncUnify, ChatBot
+
+auth_check = auth_check
+_filter_image_data = _filter_image_data
 
 
 class UnifyLangfuse(OpenAILangfuse):

--- a/langfuse/unify/unify_integration.py
+++ b/langfuse/unify/unify_integration.py
@@ -20,7 +20,7 @@ See docs for more details: https://langfuse.com/docs/integrations/openai
 from typing import Optional, List, Dict, Generator, AsyncGenerator
 from unify.exceptions import status_error_map
 from langfuse.utils.langfuse_singleton import LangfuseSingleton
-from langfuse.openai import openai, OpenAILangfuse, auth_check, _filter_image_data
+from langfuse.openai import openai, OpenAILangfuse
 
 try:
     import unify
@@ -32,7 +32,7 @@ except ImportError:
 from unify import Unify, AsyncUnify, ChatBot
 
 
-class UnifyLangfuse(OpenAILangfuse):
+class OpenAILangfuse(OpenAILangfuse):
     def initialize(self):
         self._langfuse = LangfuseSingleton().get(
             public_key=unify.langfuse_public_key,
@@ -51,12 +51,9 @@ class UnifyLangfuse(OpenAILangfuse):
         setattr(unify, "langfuse_debug", openai.langfuse_debug)
         setattr(unify, "langfuse_enabled", openai.langfuse_enabled)
         setattr(unify, "flush_langfuse", openai.flush_langfuse)
-        setattr(unify, "auth_check", auth_check)
-        setattr(unify, "_filter_image_data", _filter_image_data)
 
 
-OpenAILangfuse.initialize = UnifyLangfuse.initialize
-modifier = UnifyLangfuse()
+modifier = OpenAILangfuse()
 modifier.reassign_tracing()
 
 

--- a/langfuse/unify/unify_integration.py
+++ b/langfuse/unify/unify_integration.py
@@ -24,6 +24,8 @@ from unify.exceptions import status_error_map
 from langfuse.openai import (
     openai,
     OpenAILangfuse,
+    auth_check,
+    _filter_image_data,
 )
 
 
@@ -35,6 +37,9 @@ except ImportError:
     )
 
 from unify import Unify, AsyncUnify, ChatBot
+
+auth_check = auth_check
+_filter_image_data = _filter_image_data
 
 
 class UnifyLangfuse(OpenAILangfuse):

--- a/langfuse/unify/unify_integration.py
+++ b/langfuse/unify/unify_integration.py
@@ -29,7 +29,6 @@ from langfuse.openai import (
     OPENAI_METHODS_V0,
     OPENAI_METHODS_V1,
     _is_openai_v1,
-    modifier,
 )
 
 
@@ -52,6 +51,7 @@ def reassign_wrapper(wrapped, instance, args, kwargs):
     setattr(openai, "langfuse_host", unify.langfuse_host)
     setattr(openai, "langfuse_debug", unify.langfuse_debug)
     setattr(openai, "langfuse_enabled", unify.langfuse_enabled)
+    print(openai.langfuse_public_key)
     return wrapped(*args, **kwargs)
 
 
@@ -75,6 +75,7 @@ class UnifyLangfuse(OpenAILangfuse):
 
 
 setattr(OpenAILangfuse, "reregister_tracing", UnifyLangfuse.reregister_tracing)
+modifier = UnifyLangfuse()
 modifier.reregister_tracing()
 
 

--- a/langfuse/unify/unify_integration.py
+++ b/langfuse/unify/unify_integration.py
@@ -63,8 +63,6 @@ class UnifyLangfuse(OpenAILangfuse):
                 UnifyLangfuse.reassign_wrapper,
             )
         print(openai.langfuse_public_key)
-
-    def unify_tracing(self):
         setattr(unify, "langfuse_public_key", None)
         setattr(unify, "langfuse_secret_key", None)
         setattr(unify, "langfuse_host", None)
@@ -73,9 +71,7 @@ class UnifyLangfuse(OpenAILangfuse):
         setattr(unify, "flush_langfuse", openai.flush_langfuse)
 
 
-OpenAILangfuse.initialize = UnifyLangfuse.initialize
 modifier = UnifyLangfuse()
-modifier.unify_tracing()
 modifier.reregister_tracing()
 
 

--- a/langfuse/unify/unify_integration.py
+++ b/langfuse/unify/unify_integration.py
@@ -17,6 +17,7 @@ The integration is fully interoperable with the `observe()` decorator and the lo
 See docs for more details: https://langfuse.com/docs/integrations/openai
 """
 
+from langfuse.utils.langfuse_singleton import LangfuseSingleton
 from typing import Optional, List, Dict, Generator, AsyncGenerator
 from unify.exceptions import status_error_map
 from langfuse.openai import (
@@ -41,6 +42,18 @@ _filter_image_data = _filter_image_data
 
 
 class UnifyLangfuse(OpenAILangfuse):
+    def initialize(self):
+        self._langfuse = LangfuseSingleton().get(
+            public_key=unify.langfuse_public_key,
+            secret_key=unify.langfuse_secret_key,
+            host=unify.langfuse_host,
+            debug=unify.langfuse_debug,
+            enabled=unify.langfuse_enabled,
+            sdk_integration="unify",
+        )
+
+        return self._langfuse
+
     def unify_tracing(self):
         setattr(unify, "langfuse_public_key", None)
         setattr(unify, "langfuse_secret_key", None)
@@ -50,6 +63,7 @@ class UnifyLangfuse(OpenAILangfuse):
         setattr(unify, "flush_langfuse", self.flush)
 
 
+OpenAILangfuse.initialize = UnifyLangfuse.initialize
 modifier = UnifyLangfuse()
 modifier.unify_tracing()
 

--- a/langfuse/unify/unify_integration.py
+++ b/langfuse/unify/unify_integration.py
@@ -32,7 +32,12 @@ except ImportError:
 from unify import Unify, AsyncUnify, ChatBot
 
 
-class OpenAILangfuse(OpenAILangfuse):
+class UnifyLangfuse(OpenAILangfuse):
+    _langfuse: Optional[LangfuseSingleton] = None
+
+    def __init__(self):
+        super().__init__()
+
     def initialize(self):
         self._langfuse = LangfuseSingleton().get(
             public_key=unify.langfuse_public_key,
@@ -53,8 +58,7 @@ class OpenAILangfuse(OpenAILangfuse):
         setattr(unify, "flush_langfuse", openai.flush_langfuse)
 
 
-modifier = OpenAILangfuse()
-modifier.register_tracing()
+modifier = UnifyLangfuse()
 modifier.reassign_tracing()
 
 

--- a/langfuse/unify/unify_integration.py
+++ b/langfuse/unify/unify_integration.py
@@ -54,6 +54,7 @@ class OpenAILangfuse(OpenAILangfuse):
 
 
 modifier = OpenAILangfuse()
+modifier.register_tracing()
 modifier.reassign_tracing()
 
 

--- a/langfuse/unify/unify_integration.py
+++ b/langfuse/unify/unify_integration.py
@@ -54,7 +54,7 @@ class UnifyLangfuse(OpenAILangfuse):
             enabled=unify.langfuse_enabled,
             sdk_integration="unify",
         )
-
+        print("UnifyLangfuse initialization")
         return self._langfuse
 
     def unify_tracing(self):

--- a/langfuse/unify/unify_integration.py
+++ b/langfuse/unify/unify_integration.py
@@ -26,6 +26,7 @@ from langfuse.openai import (
     OpenAILangfuse,
     auth_check,
     _filter_image_data,
+    OpenAiDefinition,
 )
 
 
@@ -40,6 +41,27 @@ from unify import Unify, AsyncUnify, ChatBot
 
 auth_check = auth_check
 _filter_image_data = _filter_image_data
+
+
+def _unify_wrapper(func):
+    def replace_init(replacer):
+        def _with_langfuse(open_ai_resource, initialize):
+            initialize = replacer
+
+            def wrapper(wrapped, instance, args, kwargs):
+                return func(open_ai_resource, initialize, wrapped, args, kwargs)
+
+            return wrapper
+
+        return _with_langfuse
+
+    return replace_init
+
+
+@_unify_wrapper
+def replacement(
+    open_ai_resource: OpenAiDefinition, initialize, replacer, wrapped, args, kwargs
+): ...
 
 
 class UnifyLangfuse(OpenAILangfuse):

--- a/langfuse/unify/unify_integration.py
+++ b/langfuse/unify/unify_integration.py
@@ -66,14 +66,14 @@ def _unify_wrapper(func):
 
 @_unify_wrapper
 def _replacement_wrap(
-    open_ai_resource: OpenAiDefinition, initialize, wrapped, args, kwargs
+    replacer, open_ai_resource: OpenAiDefinition, initialize, wrapped, args, kwargs
 ):
     return _wrap(open_ai_resource, initialize, wrapped, args, kwargs)
 
 
 @_unify_wrapper
 def _replacement_wrap_async(
-    open_ai_resource: OpenAiDefinition, initialize, wrapped, args, kwargs
+    replacer, open_ai_resource: OpenAiDefinition, initialize, wrapped, args, kwargs
 ):
     return _wrap_async(open_ai_resource, initialize, wrapped, args, kwargs)
 

--- a/langfuse/unify/unify_integration.py
+++ b/langfuse/unify/unify_integration.py
@@ -32,11 +32,26 @@ except ImportError:
 from unify import Unify, AsyncUnify, ChatBot
 
 
+def new_setattr(name, value):
+    if name in [
+        "langfuse_public_key",
+        "langfuse_secret_key",
+        "langfuse_host",
+        "langfuse_debug",
+        "langfuse_enabled",
+        "flush_langfuse",
+    ]:
+        setattr(unify, name, value)
+        setattr(openai, name, value)
+    else:
+        setattr(unify, name, value)
+
+
+unify.__setattr__ = new_setattr
+
+
 class UnifyLangfuse(OpenAILangfuse):
     _langfuse: Optional[LangfuseSingleton] = None
-
-    def __init__(self):
-        super().__init__()
 
     def initialize(self):
         self._langfuse = LangfuseSingleton().get(
@@ -58,6 +73,7 @@ class UnifyLangfuse(OpenAILangfuse):
         setattr(unify, "flush_langfuse", openai.flush_langfuse)
 
 
+OpenAILangfuse.initialize = UnifyLangfuse.initialize
 modifier = UnifyLangfuse()
 modifier.reassign_tracing()
 

--- a/langfuse/unify/unify_integration.py
+++ b/langfuse/unify/unify_integration.py
@@ -119,7 +119,7 @@ class UnifyLangfuse(OpenAILangfuse):
         setattr(unify, "flush_langfuse", self.flush)
 
 
-OpenAILangfuse.initialize = UnifyLangfuse.initialize
+# OpenAILangfuse.initialize = UnifyLangfuse.initialize
 modifier = UnifyLangfuse()
 modifier.reregister_tracing()
 

--- a/langfuse/unify/unify_integration.py
+++ b/langfuse/unify/unify_integration.py
@@ -32,24 +32,6 @@ except ImportError:
 from unify import Unify, AsyncUnify, ChatBot
 
 
-def new_setattr(name, value):
-    if name in [
-        "langfuse_public_key",
-        "langfuse_secret_key",
-        "langfuse_host",
-        "langfuse_debug",
-        "langfuse_enabled",
-        "flush_langfuse",
-    ]:
-        setattr(unify, name, value)
-        setattr(openai, name, value)
-    else:
-        setattr(unify, name, value)
-
-
-unify.__setattr__ = new_setattr
-
-
 class UnifyLangfuse(OpenAILangfuse):
     _langfuse: Optional[LangfuseSingleton] = None
 

--- a/langfuse/unify/unify_integration.py
+++ b/langfuse/unify/unify_integration.py
@@ -20,9 +20,8 @@ See docs for more details: https://langfuse.com/docs/integrations/openai
 from typing import Optional, List, Dict, Generator, AsyncGenerator
 from unify.exceptions import status_error_map
 from wrapt import wrap_function_wrapper
-
+import openai
 from langfuse.openai import (
-    openai,
     OpenAILangfuse,
     auth_check,
     _filter_image_data,
@@ -76,6 +75,7 @@ class UnifyLangfuse(OpenAILangfuse):
 
 setattr(OpenAILangfuse, "reregister_tracing", UnifyLangfuse.reregister_tracing)
 modifier = UnifyLangfuse()
+modifier.register_tracing()
 modifier.reregister_tracing()
 
 


### PR DESCRIPTION
<!--
This template will help you to have a meaningful PR, please follow it and do not leave it blank.
-->

# PR Description
Adds langfuse controls for unify, so that one can edit langfuse parameters in the way given in the following example:
```python
unify.langfuse_public_key = "<some key>"
```.

Monkey-patches langfuse.openai wrapper functions to swap `OpenAILangfuse.initialize()` with `UnifyLangfuse.initialize()` to properly pass the langfuse parameters to the Langfuse client.

<!--
If there is no related issue, please add a short description about your PR.
-->

## Related Issue

<!--
Please use this format to link other issues with their numbers: Close #123
https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
-->

Closes #37
Closes #32

## Checklist

- [ ] Did you add a feature?
- [ ] Did you add the tests?
- [ ] Did you run your tests and are your tests passing?
- [ ] Did you follow the steps we provided?

<!--
Please mark your PR as a draft if you realise after the fact that your tests are not passing or
that your pre-commit check has some failures.

-->

### Socials

<!--
If you have Twitter, please provide it here otherwise just ignore this.
-->
